### PR TITLE
Fix: invalid link to a valid one

### DIFF
--- a/components/Layouts/TopBar.jsx
+++ b/components/Layouts/TopBar.jsx
@@ -20,7 +20,7 @@ const TopBar = ({ title, handleToggle }) => {
   };
 
   const handleLogout = () => {
-    router.push("/auth/sign_in");
+    router.push("/login");
   };
 
   const handleClick = () => {


### PR DESCRIPTION
Logout link for the "router.push()" was not a valid link